### PR TITLE
Feature/venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ $ mkvenv 3.8.1
 - bash or zsh as your shell
 - `brew install direnv`
 - `brew install pyenv`
-- `pip install virtualenv` in your default Python environment
 
 
 ## Setup

--- a/mkvenv.sh
+++ b/mkvenv.sh
@@ -29,7 +29,6 @@ function mkvenv() {
   esac; shift; done
   
   hash pyenv 2>/dev/null || { echo -e "${red}pyenv not found; try 'brew install pyenv'${nocolor}"; return 1; }
-  hash virtualenv 2>/dev/null || { echo -e "${red}virtualenv not found; try 'pip install virtualenv'${nocolor}"; return 1; }
   hash direnv 2>/dev/null || { echo -e "${red}direnv not found; try 'brew install direnv'${nocolor}"; return 1; }
 
   if [[ -f .python-version ]]; then

--- a/mkvenv.sh
+++ b/mkvenv.sh
@@ -51,7 +51,7 @@ function mkvenv() {
   fi
 
   printf "$grey"
-  virtualenv --python "$(pyenv which python)" "$venvdir" || return 1
+  python -m venv "$venvdir" || return 1
   printf "$nocolor"
 
   touch .envrc


### PR DESCRIPTION
This removes the dependency on the `virtualenv` package and uses the builtin `venv` module. 

`venv` has been around [since python 3.3](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#installing-virtualenv) and is pretty mature now, and I think we are now past the point of still needing to support python 2 🎉. 

The main benefit of this change is removing the need to install virtualenv into every pyenv version that you want to use for different projects.

Thanks for open-sourcing this, I have had great usage out of it.